### PR TITLE
Some fixes for the commands. And L7 webhook fix.

### DIFF
--- a/src/Billing/Console/Commands/ClearPastDueGracePeriods.php
+++ b/src/Billing/Console/Commands/ClearPastDueGracePeriods.php
@@ -27,7 +27,7 @@ class ClearPastDueGracePeriods extends Command
         $model = config('paddle.model');
 
         $model::whereNotNull('grace_period_ends_at')->each(function ($team) {
-            if (Carbon::now()->isPast($team->grace_period_ends_at)) {
+            if ($team->grace_period_ends_at->isPast()) {
                 $team->forceFill([
                     'paddle_subscription_id'      => null,
                     'paddle_subscription_plan_id' => null,

--- a/src/Billing/Console/Commands/ClearPastDueTrials.php
+++ b/src/Billing/Console/Commands/ClearPastDueTrials.php
@@ -27,7 +27,7 @@ class ClearPastDueTrials extends Command
         $model = config('paddle.model');
 
         $model::whereNotNull('trial_ends_at')->each(function ($team) {
-            if (Carbon::now()->isPast($team->trial_ends_at)) {
+            if ($team->trial_ends_at->isPast()) {
                 $team->forceFill([
                     'paddle_subscription_id'      => null,
                     'paddle_subscription_plan_id' => null,


### PR DESCRIPTION
The webhook gets no Accept or content-Type headers from Paddle webhook. So the request remains empty and crashes.
With this case the json()->all() gets all json information from the body. With an added collection for easy removal of the p_signature for verifying the hook.